### PR TITLE
fix: ensure 204 delete returns empty body

### DIFF
--- a/blog-service/blog_service.py
+++ b/blog-service/blog_service.py
@@ -4,7 +4,7 @@ import sqlite3
 from datetime import datetime
 from typing import Optional, Dict, List
 import aiohttp
-from fastapi import FastAPI, Request, HTTPException, Form, Depends, Query
+from fastapi import FastAPI, Request, HTTPException, Form, Depends, Query, Response
 from fastapi.responses import JSONResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -212,7 +212,7 @@ async def delete_post(post_id: int, request: Request, username: str = Depends(re
             raise HTTPException(status_code=403, detail='Forbidden: not the author')
         cursor.execute("DELETE FROM posts WHERE id = ?", (post_id,))
         conn.commit()
-    return JSONResponse(status_code=204, content=None)
+    return Response(status_code=204)
 
 @app.get("/health")
 async def handle_health():


### PR DESCRIPTION
## 배경
- DELETE /api/posts/{id} 호출 시 RuntimeError: Response content longer than Content-Length 예외가 반복적으로 발생
- 원인: 204 상태 코드와 함께 JSONResponse가 null 본문을 전송하여 HTTP 204의 “본문 없음” 규약을 위반
- 부하 테스트나 재시도 로직이 있는 클라이언트 환경에서 노이즈 로그와 불필요한 재시도가 발생할 위험 존재
## 변경 사항
1. FastAPI의 Response 클래스를 새로 임포트했습니다.
```python
from fastapi import FastAPI, Request, HTTPException, Form, Depends, Query, Response
```
2. delete_post 핸들러가 JSONResponse(status_code=204, content=None) 대신 Response(status_code=204)를 반환하도록 수정했습니다.
```python
@app.delete("/api/posts/{post_id}", status_code=204)
async def delete_post(post_id: int, request: Request, username: str = Depends(require_user)):
    with sqlite3.connect(DATABASE_PATH) as conn:
        conn.row_factory = sqlite3.Row
        cursor = conn.cursor()
        cursor.execute("SELECT author FROM posts WHERE id = ?", (post_id,))
        row = cursor.fetchone()
        if not row:
            raise HTTPException(status_code=404, detail={'error': 'Post not found'})
        if row[0] != username:
            raise HTTPException(status_code=403, detail='Forbidden: not the author')
        cursor.execute("DELETE FROM posts WHERE id = ?", (post_id,))
        conn.commit()
    return Response(status_code=204)
```
- 삭제 성공 시 HTTP 204 규약에 맞춰 본문 없이 응답합니다.
## 검증
- 수동 테스트: DELETE /api/posts/{id} 호출 후 blog-service 로그를 확인하여 예외가 더 이상 발생하지 않는 것을 확인